### PR TITLE
Kakao 할인행사, 오픈 채팅방 신고결과, 베스트 앨범, leetcode twosum

### DIFF
--- a/Hyunsu/hash/twosum.js
+++ b/Hyunsu/hash/twosum.js
@@ -1,0 +1,20 @@
+const assert = require("assert");
+
+/**
+ * hashTable이용한 풀이
+ * TimeComplexity: O(n)
+ * @param {*} nums
+ * @param {*} target
+ * @returns
+ */
+var twoSum = function (nums, target) {
+  let hash = new Map();
+  for (let i = 0; i < nums.length; i++) {
+    if (!hash.has(nums[i])) return hash.set(target - nums[i], i);
+    return [hash.get(nums[i]), i];
+  }
+};
+
+assert.deepEqual(twoSum([2, 7, 11, 15], 9), [0, 1]);
+assert.deepEqual(twoSum([3, 2, 4], 6), [1, 2]);
+assert.deepEqual(twoSum([3, 3], 6), [0, 1]);

--- a/Hyunsu/hash/베스트앨범.js
+++ b/Hyunsu/hash/베스트앨범.js
@@ -1,0 +1,54 @@
+/**
+ * 장르내에서 많이 재생된 노래 순서부터 
+ * genreFeq =  {"classic": { freqSum: number, idx:number[], freq:[ {idx:1, freq:3 }]
+ 
+ *  @param {*} genres 
+ * @param {*} plays 
+ * @returns 
+ */
+function solution(genres, plays) {
+  const answer = [];
+  const genresFreq = {};
+
+  plays.forEach((freq, idx) => {
+    const genreKey = genres[idx];
+
+    genresFreq[genreKey] = {
+      freqSum: (genresFreq[genreKey]?.freqSum || 0) + freq,
+      idx: genresFreq[genreKey]?.idx
+        ? [...genresFreq[genreKey].idx, idx]
+        : [idx],
+      freq: genresFreq[genreKey]?.freq
+        ? [...genresFreq[genreKey].freq, { idx, freq }]
+        : [{ idx, freq }],
+    };
+  });
+
+  //일단 장르별로 sort
+  const genresByFreqSum = Object.entries(genresFreq).sort((a, b) => {
+    return b[1].freqSum - a[1].freqSum;
+  });
+
+  // 장르 내 idx 정렬
+  for (const genre of genresByFreqSum) {
+    const [name, { freqSum, idx, freq }] = genre;
+
+    const idByFreq = freq.sort((a, b) => {
+      if (a.freq > b.freq) return -1;
+      if (b.freq < a.freq) return 1; // freq 내림차순
+      return a.idx - b.idx; //같으면 오름차순
+    });
+    answer.push(idByFreq);
+  }
+
+  //높은 순의 2개 가져오기
+  const result = [];
+  for (const genre of answer) {
+    for (let i = 0; i < 2; i++) {
+      if (!genre[i]) break;
+      result.push(genre[i].idx);
+    }
+  }
+
+  return result;
+}

--- a/Hyunsu/hash/신고결과받기.js
+++ b/Hyunsu/hash/신고결과받기.js
@@ -1,0 +1,45 @@
+const asserts = require("assert");
+
+/** 처리 결과 메일을 받은 횟수
+ *
+ * @param {*} id_list
+ * @param {*} report
+ * @param {*} k
+ * @returns
+ */
+function solution(id_list, report, k) {
+  let reportCount = {}; // 신고 당한 횟수 table
+  var answer = [];
+  let dashBoard = {}; // {이용자 id: 신고한id[]}
+
+  for (const id of id_list) {
+    dashBoard[id] = [];
+  }
+  //report를 순회하면서, 신고당한 횟수 count , dashBaord에 이용자id와 신고한 id업데이트
+  report.forEach((singleReport) => {
+    const [from, to] = singleReport.split(" ");
+    if (dashBoard[from].indexOf(to) > -1) return false; // 이용자 id과 신고한id가 중복일 경우 처리
+    reportCount[to] = (reportCount[to] || 0) + 1;
+    dashBoard[from].push(to);
+  });
+
+  Object.keys(dashBoard).map((id) => {
+    //id순회
+    let cnt = 0;
+    dashBoard[id].forEach((id) => {
+      reportCount[id] >= k ? (cnt += 1) : cnt;
+    });
+    answer.push(cnt);
+  });
+
+  return answer;
+}
+
+asserts.deepEqual(
+  solution(
+    ["muzi", "frodo", "apeach", "neo"],
+    ["muzi frodo", "apeach frodo", "frodo neo", "muzi neo", "apeach muzi"],
+    2
+  ),
+  [2, 1, 1, 0]
+);

--- a/Hyunsu/hash/오픈채팅방.js
+++ b/Hyunsu/hash/오픈채팅방.js
@@ -1,0 +1,77 @@
+const asserts = require("asserts");
+
+/**
+ * 문제를 잘 읽자..
+ * 익숙한 것에 너무나 당연하게 생각하고 넘어가지 말자
+ * record의 두번째 인자인 uid를( uuid처럼) 항상 붙는 prefix라고 생각하고 uid의 네번째 인덱스부터 uid라고 생각함.
+ *
+ *
+ * @param {*} record
+ * @returns
+ */
+
+function solution(record) {
+  let nameTable = {};
+  let messages = [];
+  const chatMessageTable = {
+    Enter: "님이 들어왔습니다.",
+    Leave: "님이 나갔습니다.",
+  };
+
+  for (const singleRecord of record) {
+    let [action, uid, name] = singleRecord.split(" ");
+    // uid = uid.split("").slice(3).join(""); ❌  uid는 항상 3번째 인덱스부터 시작한다고 생각하면 안된다.
+    if (action === "Enter") {
+      nameTable[uid] = name;
+      messages.push({ uid, action: chatMessageTable[action] });
+      continue;
+    }
+    if (action === "Leave") {
+      messages.push({ uid, action: chatMessageTable[action] });
+      continue;
+    }
+    if (action === "Change") {
+      nameTable[uid] = name;
+      continue;
+    }
+  }
+
+  return messages.map(({ uid, action }) => `${nameTable[uid]}${action}`);
+}
+
+asserts.deepEqual(
+  solution(["Enter uid1234 Muzi", "Leave uid1234", "Change uid1234 Prodo"]),
+  ["Prodo님이 들어왔습니다.", "Prodo님이 나갔습니다."]
+);
+
+asserts.deepEqual(
+  solution([
+    "Enter uid1234 Muzi",
+    "Leave uid1234",
+    "Enter uid2345 Muzi",
+    "Enter uid3456 Muzi",
+    "Change uid1234 Prodo",
+  ]),
+  [
+    "Prodo님이 들어왔습니다.",
+    "Prodo님이 나갔습니다.",
+    "Muzi님이 들어왔습니다.",
+    "Muzi님이 들어왔습니다.",
+  ]
+);
+
+asserts.deepEqual(
+  solution([
+    "Enter uid1234 Muzi",
+    "Enter uid4567 Prodo",
+    "Leave uid1234",
+    "Enter uid1234 Prodo",
+    "Change uid4567 Ryan",
+  ]),
+  [
+    "Prodo님이 들어왔습니다.",
+    "Ryan님이 들어왔습니다.",
+    "Prodo님이 나갔습니다.",
+    "Prodo님이 들어왔습니다.",
+  ]
+);

--- a/Hyunsu/hash/할인행사.js
+++ b/Hyunsu/hash/할인행사.js
@@ -1,3 +1,4 @@
+const assert = require("assert");
 /**
  * 접근법:
  * 10일치의 아이템과 개수를 저장하는 map 생성(=currentDiscount)
@@ -19,12 +20,17 @@
 function solution(want, number, discount) {
   var answer = 0;
   const currentDiscount = new Map();
+
+  //generate wantTable
+  const wantTable = new Map();
+  want.forEach((item, i) => wantTable.set(item, number[i]));
+  // discount
   for (let i = 0; i < discount.length; i++) {
     const item = discount[i];
     if (i < 10) {
       currentDiscount.set(item, (currentDiscount.get(item) || 0) + 1);
       if (i === 9) {
-        if (hasAllWantItem(want, currentDiscount, number)) {
+        if (hasAllWantItem(wantTable, currentDiscount)) {
           answer += 1;
         }
       }
@@ -37,8 +43,12 @@ function solution(want, number, discount) {
     let left = i - 10;
     const leftItem = discount[left];
     currentDiscount.set(leftItem, currentDiscount.get(leftItem) - 1); //음수고려
+    // 만약 0이면 지워주기
+    if (currentDiscount.get(leftItem) === 0) {
+      currentDiscount.delete(leftItem);
+    }
 
-    if (hasAllWantItem(want, currentDiscount, number)) {
+    if (hasAllWantItem(wantTable, currentDiscount)) {
       answer += 1;
     }
   }
@@ -46,18 +56,54 @@ function solution(want, number, discount) {
   return answer;
 }
 
-function hasAllWantItem(want, currentDiscount, number) {
-  let count = 0;
-  for (let i = 0; i < want.length; i++) {
-    //수량과, 아이템이 일치하는지
-    if (
-      currentDiscount.get(want[i]) &&
-      currentDiscount.get(want[i]) === number[i]
-    ) {
-      //일치하면 +1
-      count += 1;
-    }
-  }
-
-  return count === want.length;
+function hasAllWantItem(wantTable, currentDiscount) {
+  return (
+    wantTable.size === currentDiscount.size &&
+    Array.from(wantTable.keys()).every((key) => {
+      return wantTable.get(key) === currentDiscount.get(key);
+    })
+  );
 }
+// assert.deepEqual(
+//   solution(
+//     ["banana", "apple", "rice", "pork", "pot"],
+//     [3, 2, 2, 2, 1],
+//     [
+//       "chicken",
+//       "apple",
+//       "apple",
+//       "banana",
+//       "rice",
+//       "apple",
+//       "pork",
+//       "banana",
+//       "pork",
+//       "rice",
+//       "pot",
+//       "banana",
+//       "apple",
+//       "banana",
+//     ]
+//   ),
+//   3
+// );
+
+assert.deepEqual(
+  solution(
+    ["apple"],
+    [10],
+    [
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+      "banana",
+    ]
+  ),
+  0
+);


### PR DESCRIPTION
**할인 행사 수정 반영** 
-  현재 DisCount 테이블,  want테이블의 아이템과 수량 비교에서 `JSON.stringify()` 사용이 객체에서만 가능합니다. ㅠ  Map인스턴스로는 결국 O(n)의 방법밖엔 없네요. 

연속적인 카카오 문제에.. 릿코드로 잠시 넘어가 two sum풀어보았습니다. 

**오픈채팅방 문제**
-  문제를 다시 꼼꼼히 잘 읽어야겠단 생각을 했습니다. 
- `uid`문자열이 변경될 수 있다는점을 인지하지 못한채 uuid로 착각하고 숫자만 뽑은 상태가 문제였습니다. 
- 여기가 틀렸을 거라고 생각못하고 힘을 너무 빼서 한 문제남은 메뉴 리뉴얼은 내일 올리겠습니다. 

전체적으로 코드 리팩토링은 하지 않았습니다. 문제를 푸는 것에 초점을 맞추었습니다. 개선은 책과 다른분들의 코드를  참고하도록 하겠습니다.